### PR TITLE
Fix comment in env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Project name if multiple instances on one server
 COMPOSE_PROJECT_NAME=sbe_
 
-# Used as cotainer name sbe.your.domain
+# Used as container name sbe.your.domain
 DOMAIN=your.domain
 
 # Share your ssh keys with docker container


### PR DESCRIPTION
## Summary
- fix container comment in `.env.example`

## Testing
- `pytest -q` *(fails: command not found)*