### PR TITLE
Move backups to store directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ backup/config/msmtprc
 backup/.mounted/
 keyserver/config/certs/
 keyserver/data/
+store/
 *__pycache__/
 *.pyc
 *.pyo

--- a/README.md
+++ b/README.md
@@ -194,10 +194,10 @@ Each host directory contains a wrapper script that automatically passes the host
 
 ```bash
 # Using the wrapper for host1
-/opt/SBE/backup/host1/backup_server.py --daily
+/opt/SBE/store/host1/backup_server.py --daily
 
 # With retention
-/opt/SBE/backup/host1/backup_server.py --weekly --retention 4
+/opt/SBE/store/host1/backup_server.py --weekly --retention 4
 ```
 
 ### Benefits of the Universal Script
@@ -343,7 +343,7 @@ If you get "Backup script not found" errors:
 3. Make sure the wrapper script for the host is correctly created:
    ```bash
    # For a host named "server1"
-   cat /opt/SBE/backup/server1/backup_server.py
+   cat /opt/SBE/store/server1/backup_server.py
    ```
 
 ## For Existing Installations
@@ -364,11 +364,11 @@ If you have an existing installation and want to upgrade to the universal backup
 2. Create wrapper scripts for each existing host:
    ```bash
    # For each host, e.g., "server1"
-   cat > /opt/SBE/backup/server1/backup_server.py << 'EOF'
+   cat > /opt/SBE/store/server1/backup_server.py << 'EOF'
    #!/bin/bash
    python3 /opt/SBE/backup/tools/backup_server.py --server server1 "$@"
    EOF
-   chmod +x /opt/SBE/backup/server1/backup_server.py
+   chmod +x /opt/SBE/store/server1/backup_server.py
    ```
 
 3. Add the `run_backup` command:

--- a/backup/main.py
+++ b/backup/main.py
@@ -40,7 +40,10 @@ class BackupScheduler:
         else:
             # Set base directory to the SBE root (2 levels up from this script)
             self.base_dir = Path(__file__).resolve().parent.parent
-        
+
+        # Directory where actual backups are stored
+        self.store_dir = self.base_dir / "store"
+
         self.config = ConfigManager(str(self.base_dir))
         self.running = False
         self.backups_running = set()
@@ -313,7 +316,7 @@ class BackupScheduler:
             retention: Retention period in days
         """
         # Check if backup directory exists
-        backup_dir = self.base_dir / "backup" / directory
+        backup_dir = self.store_dir / directory
         
         if not backup_dir.exists():
             logger.error(f"Backup directory {backup_dir} doesn't exist")

--- a/backup/status.py
+++ b/backup/status.py
@@ -34,7 +34,10 @@ class BackupStatus:
         else:
             # Set base directory to the SBE root (2 levels up from this script)
             self.base_dir = Path(__file__).resolve().parent.parent
-        
+
+        # Directory where backups are stored
+        self.store_dir = self.base_dir / "store"
+
         self.config = ConfigManager(str(self.base_dir))
         
         # Load environment variables
@@ -159,7 +162,7 @@ class BackupStatus:
         print("-------------")
         
         # Get list of all backup directories
-        backup_dir = self.base_dir / "backup"
+        backup_dir = self.store_dir
         mounted_count = 0
         
         for server_dir in backup_dir.iterdir():

--- a/backup/tools/add_host.py
+++ b/backup/tools/add_host.py
@@ -157,7 +157,10 @@ class HostManager:
         else:
             # Set base directory to the SBE root (3 levels up from this script)
             self.base_dir = Path(__file__).resolve().parent.parent.parent
-        
+
+        # Directory where backups are stored
+        self.store_dir = self.base_dir / "store"
+
         self.config = ConfigManager(str(self.base_dir))
         self.key_manager = KeyManager()
         self.mounter = BackupMounter(str(self.base_dir))
@@ -187,7 +190,7 @@ class HostManager:
             Tuple of (success, message)
         """
         # Set paths
-        backup_dir = self.base_dir / "backup" / hostname
+        backup_dir = self.store_dir / hostname
         mounted_dir = backup_dir / ".mounted"
         backup_img = backup_dir / "backups"
         
@@ -487,9 +490,9 @@ class HostManager:
         try:
             # Use universal backup script in the tools directory
             universal_script = self.base_dir / "backup" / "tools" / "backup_server.py"
-            
+
             # Create command wrapper script
-            wrapper_script = self.base_dir / "backup" / hostname / "backup_server.py"
+            wrapper_script = self.store_dir / hostname / "backup_server.py"
             
             # Create the wrapper script content
             wrapper_content = f'''#!/bin/bash

--- a/backup/tools/backup_server.py
+++ b/backup/tools/backup_server.py
@@ -29,7 +29,7 @@ def run_backup(server_name, backup_type="daily", retention=None):
     base_dir = Path(__file__).resolve().parent.parent.parent
     
     # Get paths
-    server_dir = base_dir / "backup" / server_name
+    server_dir = base_dir / "store" / server_name
     mount_dir = server_dir / ".mounted"
     backup_dir = mount_dir / backup_type
     

--- a/backup/tools/lib/config.py
+++ b/backup/tools/lib/config.py
@@ -61,7 +61,7 @@ class ConfigManager:
         Returns:
             Dict containing server configuration
         """
-        server_dir = self.base_dir / "backup" / server_name
+        server_dir = self.base_dir / "store" / server_name
         config_path = server_dir / "server.config"
         
         if not config_path.exists():
@@ -177,7 +177,7 @@ class ConfigManager:
         Returns:
             True if successful, False otherwise
         """
-        server_dir = self.base_dir / "backup" / server_name
+        server_dir = self.base_dir / "store" / server_name
         config_path = server_dir / "server.config"
         
         try:

--- a/backup/tools/lib/key_manager.py
+++ b/backup/tools/lib/key_manager.py
@@ -220,7 +220,7 @@ class KeyManager:
             else:
                 # Assuming standard SBE structure
                 base_dir = Path(__file__).resolve().parent.parent.parent.parent
-                backup_path = base_dir / "backup" / hostname / "passphrase.backup"
+                backup_path = base_dir / "store" / hostname / "passphrase.backup"
             
             # Create parent directories if they don't exist
             backup_path.parent.mkdir(parents=True, exist_ok=True)
@@ -265,8 +265,8 @@ class KeyManager:
         else:
             # Assuming standard SBE structure
             base_dir = Path(__file__).resolve().parent.parent.parent.parent
-            backup_path = base_dir / "backup" / hostname / "passphrase.backup"
-            alt_backup_path = base_dir / "backup" / hostname / "passphrase"
+            backup_path = base_dir / "store" / hostname / "passphrase.backup"
+            alt_backup_path = base_dir / "store" / hostname / "passphrase"
         
         # Try backup file
         try:

--- a/backup/tools/lib/mount.py
+++ b/backup/tools/lib/mount.py
@@ -34,7 +34,10 @@ class BackupMounter:
         else:
             # Set base directory to the SBE root (3 levels up from this script)
             self.base_dir = Path(__file__).resolve().parent.parent.parent
-        
+
+        # Directory where backups are stored
+        self.store_dir = self.base_dir / "store"
+
         self.config = ConfigManager(str(self.base_dir))
         self.key_manager = KeyManager()
     
@@ -53,7 +56,7 @@ class BackupMounter:
             return False, f"Failed to load configuration for {server_name}"
         
         # Set paths
-        server_dir = self.base_dir / "backup" / server_name
+        server_dir = self.store_dir / server_name
         backup_img = server_dir / "backups"
         mount_dir = server_dir / ".mounted"
         
@@ -134,7 +137,7 @@ class BackupMounter:
             return False, f"Failed to load configuration for {server_name}"
         
         # Set paths
-        server_dir = self.base_dir / "backup" / server_name
+        server_dir = self.store_dir / server_name
         mount_dir = server_dir / ".mounted"
         
         # Check if mounted
@@ -177,7 +180,7 @@ class BackupMounter:
             Tuple of (success, message)
         """
         # Set paths
-        server_dir = self.base_dir / "backup" / server_name
+        server_dir = self.store_dir / server_name
         mount_dir = server_dir / ".mounted"
         
         # Check if mounted

--- a/backup/tools/mount.py
+++ b/backup/tools/mount.py
@@ -61,7 +61,10 @@ class BackupMounter:
         else:
             # Set base directory to the SBE root (3 levels up from this script)
             self.base_dir = Path(__file__).resolve().parent.parent.parent
-        
+
+        # Directory where backups are stored
+        self.store_dir = self.base_dir / "store"
+
         self.config = ConfigManager(str(self.base_dir))
         self.key_manager = KeyManager()
     
@@ -80,7 +83,7 @@ class BackupMounter:
             return False, f"Failed to load configuration for {server_name}"
         
         # Set paths
-        server_dir = self.base_dir / "backup" / server_name
+        server_dir = self.store_dir / server_name
         backup_img = server_dir / "backups"
         mount_dir = server_dir / ".mounted"
         
@@ -167,7 +170,7 @@ class BackupMounter:
             return False, f"Failed to load configuration for {server_name}"
         
         # Set paths
-        server_dir = self.base_dir / "backup" / server_name
+        server_dir = self.store_dir / server_name
         mount_dir = server_dir / ".mounted"
         
         # Check if mounted
@@ -212,7 +215,7 @@ class BackupMounter:
             Tuple of (success, message)
         """
         # Set paths
-        server_dir = self.base_dir / "backup" / server_name
+        server_dir = self.store_dir / server_name
         mount_dir = server_dir / ".mounted"
         
         # Check if mounted

--- a/backup/tools/test_mount_lib.py
+++ b/backup/tools/test_mount_lib.py
@@ -19,7 +19,7 @@ class OpenLuksDeviceTest(unittest.TestCase):
     def test_existing_mapper_generates_unique_name(self):
         tmp = tempfile.TemporaryDirectory()
         base_dir = Path(tmp.name)
-        server_dir = base_dir / "backup" / "srv"
+        server_dir = base_dir / "store" / "srv"
         server_dir.mkdir(parents=True)
         device = server_dir / "backups"
         device.touch()
@@ -66,7 +66,7 @@ class MountDirectoryTest(unittest.TestCase):
     def test_mount_uses_device_name_file(self):
         tmp = tempfile.TemporaryDirectory()
         base_dir = Path(tmp.name)
-        server_dir = base_dir / "backup" / "srv"
+        server_dir = base_dir / "store" / "srv"
         server_dir.mkdir(parents=True)
 
         # minimal config


### PR DESCRIPTION
## Summary
- avoid storing backup data inside the `backup` directory
- add a `store/` entry in `.gitignore`
- reference `store` path for host wrappers in documentation
- update Python code to use the new `store` location for server data

## Testing
- `pip install -q -r requirements.txt` *(fails: Could not find a version that satisfies the requirement PyYAML==6.0)*
- `pytest -q` *(fails: command not found)*