### PR TITLE
Add include/exclude configuration to backup.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,8 +247,10 @@ servers:
 For finer control over what gets backed up, each server directory can provide
 `include.txt` and `exclude.txt` files. These files contain standard `rsync`
 filter rules. The universal backup script automatically loads them and adds the
-patterns to the `rsync` command. You can also point to custom files in
-`server.config` using the `INCLUDE_FILE` and `EXCLUDE_FILE` options.
+patterns to the `rsync` command. Custom paths can be specified in
+`backup/config/backup.yaml` using the `include_file` and `exclude_file` options
+for each server. Legacy `server.config` entries (`INCLUDE_FILE` and
+`EXCLUDE_FILE`) are still honoured.
 
 A typical `exclude.txt` might skip system directories and temporary files:
 
@@ -277,11 +279,13 @@ server's directory (e.g. `store/host1/`).  If an `include.txt` or
 `exclude.txt` file exists there, the universal backup script adds the patterns
 to the `rsync` command automatically.  Lines starting with `#` are ignored.
 
-Alternatively you can specify custom paths in `server.config`:
+Alternatively you can specify custom paths in `backup/config/backup.yaml`:
 
-```
-INCLUDE_FILE=/path/to/include.txt
-EXCLUDE_FILE=/path/to/exclude.txt
+```yaml
+servers:
+  - backupdirectory: server1
+    include_file: /path/to/include.txt
+    exclude_file: /path/to/exclude.txt
 ```
 
 Relative paths are resolved against the server's directory.  Use this feature

--- a/backup/config/backup-example.yaml
+++ b/backup/config/backup-example.yaml
@@ -7,6 +7,8 @@ servers:
     date: "*"  # * means every day
     type: daily
     retention: 7  # Keep last 7 daily backups
+    include_file: include.txt  # Optional include patterns
+    exclude_file: exclude.txt  # Optional exclude patterns
   
   # Weekly backup - runs every Sunday at 2 AM
   - backupdirectory: ServerName
@@ -14,6 +16,8 @@ servers:
     date: Sun  # Day of week (Sun, Mon, Tue, Wed, Thu, Fri, Sat)
     type: weekly
     retention: 4  # Keep last 4 weekly backups
+    include_file: include.txt
+    exclude_file: exclude.txt
   
   # Monthly backup - runs on the 1st of each month at 3 AM
   - backupdirectory: ServerName
@@ -21,6 +25,8 @@ servers:
     date: "1"  # Day of month (1-31)
     type: monthly
     retention: 12  # Keep last 12 monthly backups
+    include_file: include.txt
+    exclude_file: exclude.txt
   
   # Yearly backup - runs on January 1st at 4 AM
   - backupdirectory: ServerName
@@ -28,3 +34,5 @@ servers:
     date: Jan-1  # Format: Month-Day (Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct, Nov, Dec)
     type: yearly
     retention: 5  # Keep last 5 yearly backups
+    include_file: include.txt
+    exclude_file: exclude.txt

--- a/backup/main.py
+++ b/backup/main.py
@@ -305,9 +305,12 @@ class BackupScheduler:
         
         # If all conditions are met, run backup
         if should_run:
-            self._run_backup(directory, backup_type, retention)
+            include_file = server_config.get("include_file")
+            exclude_file = server_config.get("exclude_file")
+            self._run_backup(directory, backup_type, retention, include_file, exclude_file)
     
-    def _run_backup(self, directory: str, backup_type: str, retention: Optional[int] = None) -> None:
+    def _run_backup(self, directory: str, backup_type: str, retention: Optional[int] = None,
+                    include_file: Optional[str] = None, exclude_file: Optional[str] = None) -> None:
         """Run a backup
         
         Args:
@@ -342,11 +345,17 @@ class BackupScheduler:
         
         # Build command
         command = [
-            sys.executable, 
-            str(universal_script), 
+            sys.executable,
+            str(universal_script),
             "--server", directory,
             f"--{backup_type}"
         ]
+
+        if include_file:
+            command.extend(["--include-file", include_file])
+
+        if exclude_file:
+            command.extend(["--exclude-file", exclude_file])
         
         if retention is not None:
             command.extend(["--retention", str(retention)])


### PR DESCRIPTION
## Summary
- allow specifying `include_file` and `exclude_file` for each server in `backup.yaml`
- pass include/exclude options from the scheduler to the backup script
- add CLI options to `backup_server.py`
- document new behaviour in README

## Testing
- `python -m py_compile backup/main.py backup/tools/backup_server.py`
- `pytest -q` *(fails: command not found)*